### PR TITLE
#3 Use is_sidebar_visible and set_sidebar_visible instead of guessing

### DIFF
--- a/AutoHideSidebar.py
+++ b/AutoHideSidebar.py
@@ -3,12 +3,13 @@
 #
 # Based on code from SyncedSideBar: https://github.com/sobstel/SyncedSideBar
 import sublime, sublime_plugin
+from collections import defaultdict
 
 PLUGIN_NAME = 'AutoHideSidebar'
 
 CHANGE_COUNT_TRIGGER_KEY = 'hide_sidebar_change_count_trigger'
 change_count_trigger = 10 # default, can be changed in prefs with above key
-change_counter = {}
+change_counter = defaultdict(int)
 
 # preferences key, default value/current calue
 behaviours = {
@@ -34,7 +35,7 @@ def set_change_count(id, count):
 
 def increment_change_count(id):
   global change_counter
-  change_counter[id] = change_counter.get(id, 0) + 1
+  change_counter[id] += 1
   return change_counter[id]
 
 def log(msg):

--- a/AutoHideSidebar.py
+++ b/AutoHideSidebar.py
@@ -68,6 +68,9 @@ class AutoHideSidebarListener(sublime_plugin.EventListener):
   def on_modified_async(self, view):
     if view.window() and len(view.window().folders()) > 0:
       if is_sidebar_visible(view.window()):
+        if view.settings().get( "is_widget" ):
+          log("In a quick panel, ignoring keypress")
+          return
         global change_counter
         change_counter += 1
         log("change_counter: %i/%i" % (change_counter, change_count_trigger))

--- a/AutoHideSidebar.py
+++ b/AutoHideSidebar.py
@@ -114,11 +114,14 @@ class AutoHideSidebarListener(sublime_plugin.EventListener):
       self.show_sidebar_and_reset_count(view)
 
   def show_sidebar_and_reset_count(self, view):
+    # not sure why but on_close/on_new/on_activated are called twice, and one of the times the view.window() is nil
+    if not view.window():
+      return
     self.reset_count(view.window().id())
     self.show_sidebar(view)
 
   def reset_count(self, window_id):
-    log("Resetting counter to zero (trigger is %i)" % change_count_trigger)
+    log("Resetting counter for window %i to zero (trigger is %i)" % (window_id, change_count_trigger))
     set_change_count(window_id, 0)
 
   def hide_sidebar(self, view):


### PR DESCRIPTION
Remove now unnecessary code for visibility tracking

The behavior when in quick panels is also fixed
